### PR TITLE
standardize expressions plus some other refactorings

### DIFF
--- a/src/main/java/expressionsimplifier/Constants.java
+++ b/src/main/java/expressionsimplifier/Constants.java
@@ -4,7 +4,6 @@ import java.util.Collections;
 import java.util.Set;
 
 public final class Constants {
-    public static final String MUL = "*";
     public static final String NEGATIVE_SIGN = "-";
     public static final String LEFT_PAREN = "(";
     public static final String RIGHT_PAREN = ")";
@@ -12,6 +11,9 @@ public final class Constants {
     public static final String NEGATIVE_ONE = "-1";
     public static final String ADD = "+";
     public static final String SUB = "-";
+    public static final String MUL = "*";
+    public static final String DIV = "/";
+    public static final String POW = "^";
 
     private Constants() {
     }

--- a/src/main/java/expressionsimplifier/ExpressionSimplifier.java
+++ b/src/main/java/expressionsimplifier/ExpressionSimplifier.java
@@ -196,8 +196,7 @@ public final class ExpressionSimplifier {
         for (var lexNode : lexNodes) {
             if (lexNode.type == TokenType.SUBEXPR) {
                 String subExpr = lexNode.token;
-                // Remove parentheses
-                subExpr = subExpr.substring(1, subExpr.length() - 1);
+                subExpr = Utils.removeParens(subExpr);
                 subTrees.add(parseExpr(subExpr));
             } else {
                 subTrees.add(new SyntaxTree(lexNode));

--- a/src/main/java/expressionsimplifier/ExpressionSimplifier.java
+++ b/src/main/java/expressionsimplifier/ExpressionSimplifier.java
@@ -133,7 +133,7 @@ public final class ExpressionSimplifier {
 
     @Contract(pure = true)
     private static @NotNull SyntaxTree foldConstants(@NotNull String operator, @NotNull SyntaxTree left, @NotNull SyntaxTree right) {
-        if (left.getTokenType() == TokenType.NUMBER && right.getTokenType() == TokenType.NUMBER) {
+        if (left.tokenTypeEquals(TokenType.NUMBER) && right.tokenTypeEquals(TokenType.NUMBER)) {
             BigDecimal leftNum = new BigDecimal(left.getToken());
             BigDecimal rightNum = new BigDecimal(right.getToken());
 
@@ -148,8 +148,8 @@ public final class ExpressionSimplifier {
 
     @Contract(pure = true)
     private static @NotNull SyntaxTree standardize(@NotNull String operator, @NotNull SyntaxTree left, @NotNull SyntaxTree right) {
-        boolean isLeftNumber = left.getTokenType() == TokenType.NUMBER;
-        boolean isRightNumber = right.getTokenType() == TokenType.NUMBER;
+        boolean isLeftNumber = left.tokenTypeEquals(TokenType.NUMBER);
+        boolean isRightNumber = right.tokenTypeEquals(TokenType.NUMBER);
         LexNode node = new LexNode(operator, TokenType.OPERATOR);
         if (operator.equals(ADD) && isLeftNumber && !isRightNumber) {
             return new SyntaxTree(node, right, left);
@@ -226,7 +226,7 @@ public final class ExpressionSimplifier {
         Deque<SyntaxTree> subTreesStack = new ArrayDeque<>();
         SyntaxTree operatorTree = null;
         for (SyntaxTree tree : trees) {
-            boolean isOperator = tree.getTokenType() == TokenType.OPERATOR;
+            boolean isOperator = tree.tokenTypeEquals(TokenType.OPERATOR);
             boolean isCorrectOperator = operators.contains(tree.getToken());
 
             if (isOperator && isCorrectOperator && tree.isLeaf()) {

--- a/src/main/java/expressionsimplifier/ExpressionType.java
+++ b/src/main/java/expressionsimplifier/ExpressionType.java
@@ -1,0 +1,23 @@
+package expressionsimplifier;
+
+import java.util.Map;
+
+public enum ExpressionType {
+    NUMBER,
+    VARIABLE,
+    SUM,
+    DIFF,
+    PROD,
+    DIV,
+    POW,
+    EXP,
+    // Catchall type for expressions that are not simple
+    COMPLEX;
+    public static final Map<String, ExpressionType> OPERATOR_TO_EXPRESSION_TYPE = Map.ofEntries(
+            Map.entry(Constants.ADD, SUM),
+            Map.entry(Constants.SUB, DIFF),
+            Map.entry(Constants.MUL, PROD),
+            Map.entry(Constants.DIV, DIV),
+            Map.entry(Constants.POW, POW)
+    );
+}

--- a/src/main/java/expressionsimplifier/LexNode.java
+++ b/src/main/java/expressionsimplifier/LexNode.java
@@ -2,6 +2,8 @@ package expressionsimplifier;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
+
 final class LexNode {
     public final @NotNull String token;
     public final @NotNull TokenType type;
@@ -14,5 +16,27 @@ final class LexNode {
     @Override
     public @NotNull String toString() {
         return token;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        LexNode lexNode = (LexNode) o;
+
+        if (!token.equals(lexNode.token)) {
+            return false;
+        }
+        return type == lexNode.type;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(token, type);
     }
 }

--- a/src/main/java/expressionsimplifier/Operator.java
+++ b/src/main/java/expressionsimplifier/Operator.java
@@ -15,11 +15,11 @@ import java.util.function.BinaryOperator;
  */
 public enum Operator {
     // Operators must be ordered by decreasing precedence.
-    POW("^", 2, Operator::pow),
-    MUL("*", 1, BigDecimal::multiply),
-    DIV("/", 1, BigDecimal::divide),
-    ADD("+", 0, BigDecimal::add),
-    SUB("-", 0, BigDecimal::subtract);
+    POW(Constants.POW, 2, Operator::pow),
+    MUL(Constants.MUL, 1, BigDecimal::multiply),
+    DIV(Constants.DIV, 1, BigDecimal::divide),
+    ADD(Constants.ADD, 0, BigDecimal::add),
+    SUB(Constants.SUB, 0, BigDecimal::subtract);
     public final String token;
     public final int precedence;
     public final BinaryOperator<BigDecimal> function;
@@ -74,7 +74,6 @@ public enum Operator {
     public static @NotNull Collection<Set<String>> tokensGroupedByPrecedence() {
         LinkedHashMap<Integer, Set<String>> precedenceToTokens = new LinkedHashMap<>();
         for (Operator op : Operator.values()) {
-
             int precedence = op.precedence;
             precedenceToTokens.putIfAbsent(precedence, new HashSet<>());
             String token = op.token;

--- a/src/main/java/expressionsimplifier/Simplifier.java
+++ b/src/main/java/expressionsimplifier/Simplifier.java
@@ -1,0 +1,6 @@
+package expressionsimplifier;
+
+@FunctionalInterface
+public interface Simplifier {
+    SyntaxTree simplify(String operator, SyntaxTree left, SyntaxTree right);
+}

--- a/src/main/java/expressionsimplifier/SyntaxTree.java
+++ b/src/main/java/expressionsimplifier/SyntaxTree.java
@@ -34,16 +34,6 @@ final class SyntaxTree {
         this.right = right;
     }
 
-    private static @NotNull String removeParens(@NotNull String expr) {
-        String firstChar = String.valueOf(expr.charAt(0));
-        String lastChar = String.valueOf(expr.charAt(expr.length() - 1));
-        if (firstChar.equals(LEFT_PAREN) && lastChar.equals(RIGHT_PAREN)) {
-            return expr.substring(1, expr.length() - 1);
-        }
-
-        return expr;
-    }
-
     public boolean isLeaf() {
         return left == null && right == null;
     }
@@ -144,11 +134,11 @@ final class SyntaxTree {
         childString = String.format("(%s)", childString);
 
         if (child.getPrecedence() >= this.getPrecedence()) {
-            childString = removeParens(childString);
+            childString = Utils.removeParens(childString);
         }
 
         if (child.isLeaf()) {
-            childString = removeParens(childString);
+            childString = Utils.removeParens(childString);
 
             if (childString.startsWith(SUB)) {
                 childString = String.format("(%s)", childString);

--- a/src/main/java/expressionsimplifier/SyntaxTree.java
+++ b/src/main/java/expressionsimplifier/SyntaxTree.java
@@ -48,7 +48,7 @@ final class SyntaxTree {
         return left == null && right == null;
     }
 
-    public @NotNull TokenType getType() {
+    public @NotNull TokenType getTokenType() {
         return node.type;
     }
 
@@ -115,12 +115,12 @@ final class SyntaxTree {
         assert left != null;
         assert right != null;
 
-        boolean isRightVariable = right.getType() == TokenType.VARIABLE;
+        boolean isRightVariable = right.getTokenType() == TokenType.VARIABLE;
         if (left.getToken().equals(NEGATIVE_ONE) && isRightVariable) {
             return String.format("-%s", right);
         }
 
-        boolean isLeftNumber = left.getType() == TokenType.NUMBER;
+        boolean isLeftNumber = left.getTokenType() == TokenType.NUMBER;
         if (isLeftNumber && isRightVariable) {
             return String.format("%s%s", left, right);
         }
@@ -164,5 +164,41 @@ final class SyntaxTree {
         }
 
         return Operator.getPrecedence(getToken());
+    }
+
+    @SuppressWarnings("java:S3776")
+    public ExpressionType getExpressionType() {
+        if (isLeaf()) {
+            if (node.type == TokenType.NUMBER) {
+                return ExpressionType.NUMBER;
+            }
+
+            if (node.type == TokenType.VARIABLE) {
+                return ExpressionType.VARIABLE;
+            }
+        }
+
+        assert left != null;
+        assert right != null;
+        if (left.isLeaf() && right.isLeaf()) {
+            if (node.token.equals(POW)) {
+                if (left.expressionTypeEquals(ExpressionType.VARIABLE) && right.expressionTypeEquals(ExpressionType.NUMBER)) {
+                    return ExpressionType.POW;
+                }
+
+                if (left.expressionTypeEquals(ExpressionType.NUMBER) && right.expressionTypeEquals(ExpressionType.VARIABLE)) {
+                    return ExpressionType.NUMBER;
+                }
+
+                return ExpressionType.COMPLEX;
+            }
+            return ExpressionType.OPERATOR_TO_EXPRESSION_TYPE.get(node.token);
+        }
+
+        return ExpressionType.COMPLEX;
+    }
+
+    public boolean expressionTypeEquals(ExpressionType type) {
+        return getExpressionType() == type;
     }
 }

--- a/src/main/java/expressionsimplifier/SyntaxTree.java
+++ b/src/main/java/expressionsimplifier/SyntaxTree.java
@@ -38,8 +38,8 @@ final class SyntaxTree {
         return left == null && right == null;
     }
 
-    public @NotNull TokenType getTokenType() {
-        return node.type;
+    public boolean tokenTypeEquals(@NotNull TokenType type) {
+        return node.type == type;
     }
 
     public @NotNull String getToken() {
@@ -105,12 +105,12 @@ final class SyntaxTree {
         assert left != null;
         assert right != null;
 
-        boolean isRightVariable = right.getTokenType() == TokenType.VARIABLE;
+        boolean isRightVariable = right.tokenTypeEquals(TokenType.VARIABLE);
         if (left.getToken().equals(NEGATIVE_ONE) && isRightVariable) {
             return String.format("-%s", right);
         }
 
-        boolean isLeftNumber = left.getTokenType() == TokenType.NUMBER;
+        boolean isLeftNumber = left.tokenTypeEquals(TokenType.NUMBER);
         if (isLeftNumber && isRightVariable) {
             return String.format("%s%s", left, right);
         }

--- a/src/main/java/expressionsimplifier/SyntaxTree.java
+++ b/src/main/java/expressionsimplifier/SyntaxTree.java
@@ -86,7 +86,7 @@ final class SyntaxTree {
         // Implicit multiplication
         if (node.token.equals(MUL)) {
             String expr = handleImplicitMultiplication();
-            if (!expr.isEmpty()) {
+            if (expr != null) {
                 return expr;
             }
         }
@@ -101,7 +101,7 @@ final class SyntaxTree {
         return String.format("%s%s%s", leftString, node, rightString);
     }
 
-    private @NotNull String handleImplicitMultiplication() {
+    private @Nullable String handleImplicitMultiplication() {
         assert left != null;
         assert right != null;
 
@@ -125,7 +125,7 @@ final class SyntaxTree {
             return String.format("(%s)(%s)", left, right);
         }
 
-        return "";
+        return null;
     }
 
     private @NotNull String formatParens(@NotNull SyntaxTree child) {

--- a/src/main/java/expressionsimplifier/Utils.java
+++ b/src/main/java/expressionsimplifier/Utils.java
@@ -1,0 +1,20 @@
+package expressionsimplifier;
+
+import org.jetbrains.annotations.NotNull;
+
+import static expressionsimplifier.Constants.LEFT_PAREN;
+import static expressionsimplifier.Constants.RIGHT_PAREN;
+
+public final class Utils {
+    private Utils() {
+    }
+    public static @NotNull String removeParens(@NotNull String expr) {
+        String firstChar = String.valueOf(expr.charAt(0));
+        String lastChar = String.valueOf(expr.charAt(expr.length() - 1));
+        if (firstChar.equals(LEFT_PAREN) && lastChar.equals(RIGHT_PAREN)) {
+            return expr.substring(1, expr.length() - 1);
+        }
+
+        return expr;
+    }
+}

--- a/src/test/java/expressionsimplifier/ExpressionSimplifierTest.java
+++ b/src/test/java/expressionsimplifier/ExpressionSimplifierTest.java
@@ -11,7 +11,7 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ExpressionSimplifierTest {
-    public static @NotNull Stream<Arguments> arithmeticExpressions() {
+    public static @NotNull Stream<Arguments> expressions() {
         return Stream.of(
                 Arguments.of("1", "1"),
                 Arguments.of("1+1", "2"),
@@ -22,40 +22,14 @@ class ExpressionSimplifierTest {
                 Arguments.of("-1*-1", "1"),
                 Arguments.of("1+2*3-(-3)*(-1)+(-1)(-1^5-2^3)", "13"),
                 Arguments.of("(-1)^3", "-1"),
-                Arguments.of("3*0.1+(-0.1)", "0.2")
-        );
-    }
-
-    public static @NotNull Stream<Arguments> algebraExpressionsWithValues() {
-        return Stream.of(
-                Arguments.of("x", List.of("x=1"), "1"),
-                Arguments.of("-x", List.of("x=1"), "-1"),
-                Arguments.of("x", List.of("x=-1"), "-1"),
-                Arguments.of("2x-(-3)*4+x*x", List.of("x=2"), "20")
-        );
-    }
-
-    public static @NotNull Stream<Arguments> expressions() {
-        return Stream.of(
-                Arguments.of("x"),
-                Arguments.of("-x"),
-                Arguments.of("2*x"),
-                Arguments.of("2*x-3"),
-                Arguments.of("2*x-(-3)*4"),
-                Arguments.of("-1*x*x*(-1)"),
-                Arguments.of("x*y+x-y/y-2(x+y)")
-        );
-    }
-
-    public static @NotNull Stream<Arguments> expressionsToBeParenthesized() {
-        return Stream.of(
+                Arguments.of("3*0.1+(-0.1)", "0.2"),
                 Arguments.of("1", "1"),
                 Arguments.of("1+1", "2"),
                 Arguments.of("-1", "-1"),
                 Arguments.of("x", "x"),
                 Arguments.of("x+y", "x + y"),
                 Arguments.of("x+1", "x + 1"),
-                Arguments.of("(-1+2)+x", "1 + x"),
+                Arguments.of("(-1+2)+x", "x + 1"),
                 Arguments.of("-x", "-x"),
                 Arguments.of("x-y", "x - y"),
                 Arguments.of("x+y+1", "x + y + 1"),
@@ -67,47 +41,53 @@ class ExpressionSimplifierTest {
                 Arguments.of("2(x+y)", "2(x + y)"),
                 Arguments.of("x*y*z", "x*y*z"),
                 Arguments.of("2*-x", "-2x"),
-                Arguments.of("1+(2*x)", "1 + 2x")
-        );
-    }
-
-    public static @NotNull Stream<Arguments> expressionsToBeStandardized() {
-        return Stream.of(
+                Arguments.of("1+(2*x)", "2x + 1"),
                 Arguments.of("1", "1"),
                 Arguments.of("1+x", "x + 1"),
                 Arguments.of("x+1", "x + 1"),
                 Arguments.of("x+x^2", "x^2 + x"),
                 Arguments.of("x^2+x", "x^2 + x"),
                 Arguments.of("x^2+x^3", "x^3 + x^2"),
-                Arguments.of("x*2", "2*x"),
-                Arguments.of("2*x", "2*x"),
-                Arguments.of("x*2*y", "2*x*y")
+                Arguments.of("x*2", "2x"),
+                Arguments.of("2*x", "2x"),
+                Arguments.of("x*2*y", "2x*y")
+        );
+    }
+
+    public static @NotNull Stream<Arguments> expressionsWithAssignedVariables() {
+        return Stream.of(
+                Arguments.of("x", List.of("x=1"), "1"),
+                Arguments.of("-x", List.of("x=1"), "-1"),
+                Arguments.of("x", List.of("x=-1"), "-1"),
+                Arguments.of("2x-(-3)*4+x*x", List.of("x=2"), "20"),
+                Arguments.of("x*y", List.of("x=1"), "y"),
+                Arguments.of("x*y", List.of("z=1"), "x*y")
         );
     }
 
     @ParameterizedTest
-    @MethodSource("arithmeticExpressions")
+    @MethodSource("expressions")
     void simplifyArithmeticExpressionsTest(@NotNull String expr, @NotNull String expected) throws InvalidExpressionException {
         String actual = ExpressionSimplifier.simplifyExpr(expr);
         assertEquals(expected, actual);
     }
 
     @ParameterizedTest
-    @MethodSource("expressionsToBeParenthesized")
+    @MethodSource("expressions")
     void simplifyExpressionsWithCorrectParensTest(@NotNull String expr, @NotNull String expected) throws InvalidExpressionException {
         String actual = ExpressionSimplifier.simplifyExpr(expr);
         assertEquals(expected, actual);
     }
 
     @ParameterizedTest
-    @MethodSource("expressionsToBeStandardized")
+    @MethodSource("expressions")
     void standardizeExpressionsTest(@NotNull String expr, @NotNull String expected) throws InvalidExpressionException {
         String actual = ExpressionSimplifier.simplifyExpr(expr);
         assertEquals(expected, actual);
     }
 
     @ParameterizedTest
-    @MethodSource("algebraExpressionsWithValues")
+    @MethodSource("expressionsWithAssignedVariables")
     void evaluateAlgebraTest(@NotNull String expr, @NotNull List<String> variableValues, String expected) throws InvalidExpressionException {
         String actual = ExpressionSimplifier.simplifyExpr(expr, variableValues.toArray(String[]::new));
         assertEquals(expected, actual);


### PR DESCRIPTION
Standardize expressions so that 1 + x -> x + 1, x\*2 -> 2x, x + x^2 -> x^2 + x
Limitations 1 + x + y -> x + 1 + y, not x + y + 1 as expected.
In general these applications of associativity won't cross the boundaries of parentheses i.e. x\*(y\*2) will not be rearranged to 2\*x\*y. This might be addressed later.